### PR TITLE
Update AccountsLogic usage and organize CurrentAccount

### DIFF
--- a/PathiHub.tests/AccountsLogicTests.cs
+++ b/PathiHub.tests/AccountsLogicTests.cs
@@ -14,7 +14,7 @@ public class AccountsLogicTests
     {
         int count = _accountsLogic.GetAccounts().Count;
         var acc = new AccountModel(count + 1, "test", "test", "test", "test");
-        AccountsLogic.UpdateList(acc);
+        _accountsLogic.UpdateList(acc);
         Assert.AreEqual(count + 1, _accountsLogic.GetAccounts().Count);
         Assert.AreEqual(count + 1, _accountsLogic.GetById(count + 1).Id);
     }
@@ -23,7 +23,7 @@ public class AccountsLogicTests
     public void GetByIdTest()
     {
         var acc = new AccountModel(_accountsLogic.GetAccounts().Count + 1, "test", "test", "test", "test");
-        AccountsLogic.UpdateList(acc);
+        _accountsLogic.UpdateList(acc);
         AccountModel account = _accountsLogic.GetById(_accountsLogic.GetAccounts().Count);
         Assert.AreEqual(account.EmailAddress, "test");
         Assert.AreEqual(account.Password, "test");
@@ -34,7 +34,7 @@ public class AccountsLogicTests
     public void CheckLoginTest()
     {
         var acc = new AccountModel(_accountsLogic.GetAccounts().Count + 1, "test", "test", "test", "test");
-        AccountsLogic.UpdateList(acc);
+        _accountsLogic.UpdateList(acc);
         AccountModel account = _accountsLogic.CheckLogin("test", "test");
         Assert.AreEqual(account.EmailAddress, "test");
         Assert.AreEqual(account.Password, "test");

--- a/PathiHub/Logic/AccountsLogic.cs
+++ b/PathiHub/Logic/AccountsLogic.cs
@@ -12,15 +12,14 @@ public class AccountsLogic
     //Static properties are shared across all instances of the class
     //This can be used to get the current logged in account from anywhere in the program
     //private set, so this can only be set by the class itself
-    static public AccountModel? CurrentAccount { get; private set; }
-
+    
     public AccountsLogic()
     {
         _accounts = AccountsAccess.LoadAll();
     }
 
 
-    public static void UpdateList(AccountModel acc)
+    public void UpdateList(AccountModel acc)
     {
         //Find if there is already an model with the same id
         int index = _accounts.FindIndex(s => s.Id == acc.Id);
@@ -53,8 +52,9 @@ public class AccountsLogic
         {
             return null;
         }
-        CurrentAccount = _accounts.Find(i => i.EmailAddress == email && i.Password == password);
-        return CurrentAccount;
+        AccountModel account = _accounts.Find(i => i.EmailAddress == email && i.Password == password);
+        Helpers.CurrentAccount = account;
+        return account;
     }
     
     public List<AccountModel> GetAccounts()

--- a/PathiHub/Logic/Helpers.cs
+++ b/PathiHub/Logic/Helpers.cs
@@ -1,6 +1,8 @@
 //In deze class gaan we de alle helpers toevoegen
 public class Helpers
 {
+    //deze variabele is nodig om application wide de logged in gebruiker bij te houden.
+    public static AccountModel? CurrentAccount { get; set; }    
     
     //deze functie schrijft een char uit meerdere keren 
     public static void  CharLine(char CharItem,int NumberOfPrints)

--- a/PathiHub/Presentation/UserRegistration.cs
+++ b/PathiHub/Presentation/UserRegistration.cs
@@ -108,7 +108,7 @@ public class UserRegistration
         
         AccountsLogic accountsLogic = new AccountsLogic();
         AccountModel userAccount = new AccountModel(index, userEmail, userPassword, Name, "User");
-        AccountsLogic.UpdateList(userAccount);
+        accountsLogic.UpdateList(userAccount);
 
         Console.ForegroundColor = ConsoleColor.Cyan;
         Console.WriteLine("User account created successfully.");


### PR DESCRIPTION
Update AccountsLogic to use instance methods rather than static in 'UserRegistration.cs' and 'AccountsLogicTests.cs'. Static usage was unnecessary and confused the codebase in instances where it was not required. 'UpdateList' method in 'AccountsLogic.cs' is changed to an instance method for consistency. 'CurrentAccount' property moved from 'AccountsLogic.cs' to 'Helpers.cs' to allow application wide access. Code is now more modular and easy to understand.